### PR TITLE
fix: redundant for loops and incorrect mouse events

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,7 +42,7 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
             alignment: Alignment.center,
             children: [
               ShaderBuffers(
-                // key: UniqueKey(),
+                key: UniqueKey(),
                 controller: controller,
                 // width: 250,
                 // height: 300,

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/lib/src/layer_buffer.dart
+++ b/lib/src/layer_buffer.dart
@@ -112,11 +112,9 @@ class LayerBuffer {
 
     // Load all the assets textures if any
     if (channels == null) return true;
-    for (var i = 0; i < channels!.length; ++i) {
-      for (final element in channels!) {
-        if (!element.isInited) {
-          if (!await channels![i].init()) return false;
-        }
+    for (final element in channels!) {
+      if (!element.isInited) {
+        if (!await element.init()) return false;
       }
     }
     return true;
@@ -151,10 +149,10 @@ class LayerBuffer {
       ..setFloat(1, realPixels.height)
       ..setFloat(2, iTime) // iTime
       ..setFloat(3, iFrame) // iFrame
-      ..setFloat(4, iMouse.x) // iMouse
-      ..setFloat(5, iMouse.y)
-      ..setFloat(6, iMouse.z)
-      ..setFloat(7, iMouse.w);
+      ..setFloat(4, iMouse.x * _deviceAspectRatio * scaleRenderView) // iMouse
+      ..setFloat(5, iMouse.y * _deviceAspectRatio * scaleRenderView)
+      ..setFloat(6, iMouse.z * _deviceAspectRatio * scaleRenderView)
+      ..setFloat(7, iMouse.w * _deviceAspectRatio * scaleRenderView);
 
     /// eventually add more floats uniforms from [floatsUniforms]
     for (var i = 0; i < (uniforms?.uniforms.length ?? 0); i++) {
@@ -172,11 +170,9 @@ class LayerBuffer {
         if (channels![i].isSelf) {
           img = layerImage ?? blankImage!;
         } else {
-          if (channels![i].buffer?.layerImage == null) {
-            img = channels![i].texture;
-          }
+          img = channels![i].buffer?.layerImage ?? blankImage!;
         }
-        _shader!.setImageSampler(i, img ?? blankImage!);
+        _shader!.setImageSampler(i, img);
       }
     }
 


### PR DESCRIPTION
## Description

The fixes are described in Issues: #8 #9 

After testing, all example code works correctly, but I still don’t understand why, in the example below,
```dart
ShaderBuffers(
  key: UniqueKey(),
),
```

if UniqueKey() is not provided, mouse interaction does not work in part of the example code.

To be honest, I have very strong requirements for multi-shader workflows, and combined with some personal perfectionism, I’m trying to write my own rendering framework.

At the moment, I mainly still need to solve the following problems:

- toImage in Flutter produces RGBA8, which causes various issues when used as a buffer input for the next pass
- Keyboard input
- Audio input (possibly)
- Audio output (possibly)       
- Noise input (which also requires solving the 8-bit image issue)

In addition, the usage patterns and overall API ergonomics will require a fair amount of design work. I’ve already started implementing this myself.

Thank you for your contributions to this repository.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)